### PR TITLE
Mesh.Optimize() no longer exists

### DIFF
--- a/MeshSplit.cs
+++ b/MeshSplit.cs
@@ -230,7 +230,7 @@ public class MeshSplit : MonoBehaviour
         m.triangles = tris.ToArray();
         m.uv = uvs.ToArray();
 
-        m.Optimize();
+        UnityEditor.MeshUtility.Optimize(m);
         m.RecalculateNormals();
 
         // assign the new mesh to submeshes mesh filter


### PR DESCRIPTION
See http://answers.unity3d.com/questions/1250034/meshoptimize-obsolete-in-unity-5505b.html
It has been replaced with MeshUtility.Optimize, see https://docs.unity3d.com/ScriptReference/MeshUtility.Optimize.html